### PR TITLE
added check for stdio option before trying to redirect output

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,10 @@ GulpProcess.prototype.start = function() {
         }
       });
 
-  p.stdout.on('data', function(b) { gutil.log(b.toString()); });
-  p.stderr.on('data', function(b) { gutil.log(b.toString()); });
+  if (!this.opts.stdio) {
+    p.stdout.on('data', function(b) { gutil.log(b.toString()); });
+    p.stderr.on('data', function(b) { gutil.log(b.toString()); });
+  }
 };
 
 GulpProcess.prototype.stop = function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-process",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "gulp plugin for running and automatically restarting processes",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
When passing the stdio option 'ignore' for npm spawn() to start() the following error results:

```
...
...
[19:34:29] TypeError: Cannot read property 'on' of null 
   at GulpProcess.start  <project>/node_modules/gulp-process/index.js:39:13)
...
...
```

This is because doing so disables stdout for the spawn process and thus there isn't anything to read.  I figured most of the options would break this code so I just added a check to not redirect output if that option is set at all.

You may ask why would you not want stdout?  I had a noisy app server running through browser-sync proxy polluting other output from gulp without a way to silence it.

Also added a version bump for good measure.
